### PR TITLE
updates for version 3.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,10 +16,9 @@ jobs:
     strategy:
       matrix:
         php-versions:
-          - "7.3"
-          - "7.4"
-          - "8.0"
           - "8.1"
+          - "8.2"
+          - "8.3"
 
     name: "php-osm-tiles build - PHP ${{ matrix.php-versions }}"
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ composer.lock
 
 .php_cs.cache
 .phpunit.result.cache
+.phpunit.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ file. This project adheres to [Semantic Versioning](https://semver.org/).
 Updates should follow the [Keep a CHANGELOG](http://keepachangelog.com/)
 principles.
 
+## [3.0.0] - 2023-12-04
+
+### Added
+
+- support for PHP 8.3
+
+### Removed
+
+- support for PHP 7.3
+- support for PHP 7.4
+- support for PHP 8.0
+
+### Deprecated
+
+- getter methods in `Tile` and `LatLng` classes, use public properties instead
+
 ## [2.0.0] - 2021-03-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PHP OSM Tiles
 
-This library helps converting OpenStreetMap (OSM) map tile numbers to
+This library helps to convert OpenStreetMap (OSM) map tile numbers to
 geographical coordinates and vice versa.
 
 [![PHP OSM Tiles Tests](https://github.com/ministryofweb/php-osm-tiles/actions/workflows/php.yml/badge.svg)](https://github.com/ministryofweb/php-osm-tiles/actions/workflows/php.yml)
@@ -15,9 +15,9 @@ composer require ministryofweb/php-osm-tiles
 
 ## Compatibility
 
-The PHP OSM Tiles library requires PHP >= 7.3.
+The PHP OSM Tiles library requires PHP >= 8.1.
 
-If support for older PHP versions is needed, the PHP OSM Tiles library can be installed at version 1.0 (PHP 7.1 and PHP 7.2) or version 0.1.0 (PHP 7.0).
+If support for older PHP versions is needed, the PHP OSM Tiles library can be installed at version 2.0 (PHP 7.3, PHP 7.4 and PHP 8.0), 1.0 (PHP 7.1 and PHP 7.2) or version 0.1.0 (PHP 7.0).
 
 ## Usage/Examples
 
@@ -35,7 +35,7 @@ $zoom      = 13;
 
 $tile = $converter->toTile($point, $zoom);
 
-printf('/tiles/%d/%d/%d.png', $zoom, $tile->getX(), $tile->getY());
+printf('/tiles/%d/%d/%d.png', $zoom, $tile->x, $tile->y);
 ```
 
 The code above produces the output below:
@@ -57,7 +57,7 @@ $tile     = new Tile(4400, 2687, 13);
 
 $point = $converter->toLatLng($tile);
 
-printf('%.5f, %.5f', $point->getLat(), $point->getLng());
+printf('%.5f, %.5f', $point->lat, $point->lat);
 ```
 
 The code above produces the output below:
@@ -79,7 +79,7 @@ use MinistryOfWeb\OsmTiles\TileBounds;
 
 $tile = Tile::fromLocation(new LatLng(52.5, 13.5));
 
-echo 'South-eastern point for tile is located at: ' . TileBounds::getSouthEast($tile)->getLat() . ', ' . TileBounds::getSouthEast($tile)->getLng() . PHP_EOL;
+echo 'South-eastern point for tile is located at: ' . TileBounds::getSouthEast($tile)->lat . ', ' . TileBounds::getSouthEast($tile)->lng . PHP_EOL;
 ```
 
 The code above produces the output below:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "coordinate"
   ],
   "require": {
-    "php": ">=7.3"
+    "php": "^8.1"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.13",
@@ -20,9 +20,9 @@
     "php-parallel-lint/php-parallel-lint": "^1.2",
     "phpmd/phpmd": "^2.9",
     "phpstan/phpstan": "^0.12.81",
-    "phpunit/phpunit": "^9.5",
-    "squizlabs/php_codesniffer": "^3.5",
-    "vimeo/psalm": "^4.0"
+    "phpunit/phpunit": "^10.0",
+    "squizlabs/php_codesniffer": "^3.7",
+    "vimeo/psalm": "^5.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage processUncoveredFiles="true">
-    <include>
-      <directory suffix=".php">./src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage/>
   <testsuites>
     <testsuite name="Unit">
       <directory suffix="Test.php">./tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,6 +2,8 @@
 <psalm
     errorLevel="1"
     resolveFromConfigFile="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/Converter.php
+++ b/src/Converter.php
@@ -8,17 +8,11 @@ use InvalidArgumentException;
 use RuntimeException;
 
 /**
- * Class Converter.
- *
  * @see https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
  */
 class Converter
 {
     /**
-     * @param LatLng $latLng
-     * @param int $zoom
-     *
-     * @return Tile
      * @throws RuntimeException
      */
     public function toTile(LatLng $latLng, int $zoom): Tile
@@ -27,9 +21,9 @@ class Converter
             throw new RuntimeException('Invalid Zoom level (must be an integer > 0)');
         }
 
-        $tileX = (int)floor((($latLng->getLng() + 180) / 360) * (2 ** $zoom));
+        $tileX = (int)floor((($latLng->lng + 180) / 360) * (2 ** $zoom));
         $tileY = (int)floor(
-            (1 - log(tan(deg2rad($latLng->getLat())) + 1 / cos(deg2rad($latLng->getLat()))) / M_PI) / 2 * (2 ** $zoom)
+            (1 - log(tan(deg2rad($latLng->lat)) + 1 / cos(deg2rad($latLng->lat))) / M_PI) / 2 * (2 ** $zoom)
         );
 
         return new Tile($tileX, $tileY, $zoom);
@@ -38,25 +32,17 @@ class Converter
     /**
      * The resulting lat/lon pair is located at the north-west node of the tile.
      *
-     * @param Tile $tile
-     *
-     * @return LatLng
      * @throws InvalidArgumentException
      */
     public function toLatLng(Tile $tile): LatLng
     {
-        $zPow = 2 ** $tile->getZoom();
-        $lat = rad2deg(atan(sinh(M_PI * (1 - 2 * $tile->getY() / $zPow))));
-        $lng = $tile->getX() / $zPow * 360.0 - 180.0;
+        $zPow = 2 ** $tile->zoom;
+        $lat = rad2deg(atan(sinh(M_PI * (1 - 2 * $tile->y / $zPow))));
+        $lng = $tile->x / $zPow * 360.0 - 180.0;
 
         return new LatLng($lat, $lng);
     }
 
-    /**
-     * @param int $zoom
-     *
-     * @return bool
-     */
     private function isValidZoom(int $zoom): bool
     {
         return $zoom > 0;

--- a/src/LatLng.php
+++ b/src/LatLng.php
@@ -12,24 +12,9 @@ use InvalidArgumentException;
 class LatLng
 {
     /**
-     * @var float
-     */
-    private $lat;
-
-    /**
-     * @var float
-     */
-    private $lng;
-
-    /**
-     * LatLng constructor.
-     *
-     * @param float $lat
-     * @param float $lng
-     *
      * @throws InvalidArgumentException
      */
-    public function __construct(float $lat, float $lng)
+    public function __construct(public readonly float $lat, public readonly float $lng)
     {
         if ($lat < -90.0 || $lat > 90.0) {
             throw new InvalidArgumentException('Latitude must be between -90.0 and 90.0');
@@ -38,9 +23,6 @@ class LatLng
         if ($lng < -180.0 || $lng > 180.0) {
             throw new InvalidArgumentException('Longitude must be between -180.0 and 180.0');
         }
-
-        $this->lat = $lat;
-        $this->lng = $lng;
     }
 
     public static function fromTile(Tile $tile): self
@@ -49,7 +31,7 @@ class LatLng
     }
 
     /**
-     * @return float
+     * @deprecated use property instead
      */
     public function getLat(): float
     {
@@ -57,7 +39,7 @@ class LatLng
     }
 
     /**
-     * @return float
+     * @deprecated use property instead
      */
     public function getLng(): float
     {

--- a/src/Tile.php
+++ b/src/Tile.php
@@ -7,61 +7,34 @@ namespace MinistryOfWeb\OsmTiles;
 use InvalidArgumentException;
 
 /**
- * Class Tile.
- *
  * @see https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames
  */
 class Tile
 {
     /**
-     * @var int
-     */
-    private $tileX;
-
-    /**
-     * @var int
-     */
-    private $tileY;
-
-    /**
-     * @var int
-     */
-    private $zoom;
-
-    /**
-     * Tile constructor.
-     *
-     * @param int $tileX
-     * @param int $tileY
-     * @param int $zoom
-     *
      * @throws InvalidArgumentException
      */
-    public function __construct(int $tileX, int $tileY, int $zoom)
+    public function __construct(public readonly int $x, public readonly int $y, public readonly int $zoom)
     {
         if ($zoom <= 0) {
             throw new InvalidArgumentException('zoom must be >= 1');
         }
 
-        if ($tileX < 0) {
+        if ($x < 0) {
             throw new InvalidArgumentException('x cannot be < 0');
         }
 
-        if ($tileX > (2 ** $zoom - 1)) {
+        if ($x > (2 ** $zoom - 1)) {
             throw new InvalidArgumentException('x cannot be > (2^zoom - 1)');
         }
 
-        if ($tileY < 0) {
+        if ($y < 0) {
             throw new InvalidArgumentException('y cannot be < 0');
         }
 
-        if ($tileY > (2 ** $zoom - 1)) {
+        if ($y > (2 ** $zoom - 1)) {
             throw new InvalidArgumentException('y cannot be > (2^zoom - 1)');
         }
-
-        $this->tileX = $tileX;
-        $this->tileY = $tileY;
-        $this->zoom = $zoom;
     }
 
     public static function fromLocation(LatLng $location, int $zoom): self
@@ -70,23 +43,23 @@ class Tile
     }
 
     /**
-     * @return int
+     * @deprecated use property instead
      */
     public function getX(): int
     {
-        return $this->tileX;
+        return $this->x;
     }
 
     /**
-     * @return int
+     * @deprecated use property instead
      */
     public function getY(): int
     {
-        return $this->tileY;
+        return $this->y;
     }
 
     /**
-     * @return int
+     * @deprecated use property instead
      */
     public function getZoom(): int
     {

--- a/src/TileBounds.php
+++ b/src/TileBounds.php
@@ -13,16 +13,16 @@ class TileBounds
 
     public static function getNorthEast(Tile $tile): LatLng
     {
-        return LatLng::fromTile(new Tile($tile->getX() + 1, $tile->getY(), $tile->getZoom()));
+        return LatLng::fromTile(new Tile($tile->x + 1, $tile->y, $tile->zoom));
     }
 
     public static function getSouthEast(Tile $tile): LatLng
     {
-        return LatLng::fromTile(new Tile($tile->getX() + 1, $tile->getY() + 1, $tile->getZoom()));
+        return LatLng::fromTile(new Tile($tile->x + 1, $tile->y + 1, $tile->zoom));
     }
 
     public static function getSouthWest(Tile $tile): LatLng
     {
-        return LatLng::fromTile(new Tile($tile->getX(), $tile->getY() + 1, $tile->getZoom()));
+        return LatLng::fromTile(new Tile($tile->x, $tile->y + 1, $tile->zoom));
     }
 }

--- a/tests/LatLngTest.php
+++ b/tests/LatLngTest.php
@@ -12,13 +12,13 @@ class LatLngTest extends TestCase
     {
         $latLng = new LatLng(52.5, 13.5);
 
-        self::assertSame(52.5, $latLng->getLat());
+        self::assertSame(52.5, $latLng->lat);
     }
 
     public function testIfGetYWorksAsExpected(): void
     {
         $latLng = new LatLng(52.5, 13.5);
 
-        self::assertSame(13.5, $latLng->getLng());
+        self::assertSame(13.5, $latLng->lng);
     }
 }

--- a/tests/TileTest.php
+++ b/tests/TileTest.php
@@ -13,21 +13,21 @@ class TileTest extends TestCase
     {
         $tile = new Tile(32000, 31930, 15);
 
-        self::assertSame(32000, $tile->getX());
+        self::assertSame(32000, $tile->x);
     }
 
     public function testIfGetYWorksAsExpected(): void
     {
         $tile = new Tile(32000, 31930, 15);
 
-        self::assertSame(31930, $tile->getY());
+        self::assertSame(31930, $tile->y);
     }
 
     public function testIfGetZoomWorksAsExpected(): void
     {
         $tile = new Tile(32000, 31930, 15);
 
-        self::assertSame(15, $tile->getZoom());
+        self::assertSame(15, $tile->zoom);
     }
 
     public function testIfZeroZoomValueThrowsAnException(): void


### PR DESCRIPTION
- support for latest PHP versions
- remove support for PHP 7.3, PHP 7.4 and PHP 8.0
- use constructor property promotion
- introduce public readonly properties
- deprecate getter methods
- update test matrix for GitHub CI workflow